### PR TITLE
Cleanup & Fix main executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(moveit_sim_controller)
 
 # C++ 11

--- a/src/moveit_sim_hw_interface.cpp
+++ b/src/moveit_sim_hw_interface.cpp
@@ -94,9 +94,10 @@ void MoveItSimHWInterface::loadDefaultJointValues()
   {
     ROS_WARN_STREAM_NAMED(name_, "Unable to find pose " << joint_model_group_pose_ << " for the fake controller "
                                                                                       "manager");
-    return;
   }
-  ROS_INFO_STREAM_NAMED(name_, "Set joints to pose " << joint_model_group_pose_);
+  else {
+    ROS_INFO_STREAM_NAMED(name_, "Set joints to pose " << joint_model_group_pose_);
+  }
 
   for (std::size_t i = 0; i < joint_names_.size(); ++i)
   {

--- a/src/moveit_sim_hw_main.cpp
+++ b/src/moveit_sim_hw_main.cpp
@@ -39,6 +39,15 @@
 #include <ros_control_boilerplate/generic_hw_control_loop.h>
 #include <moveit_sim_controller/moveit_sim_hw_interface.h>
 
+// Support released kinetic & melodic versions of GenericHWControlLoop
+template <typename T, typename = decltype(T::run)>
+inline void LOOP_RUN(T& loop) {
+  loop.run();
+};
+template <typename T> inline void LOOP_RUN(T& loop) {
+  ros::waitForShutdown();
+};
+
 int main(int argc, char** argv)
 {
   ros::init(argc, argv, "moveit_sim_hw_main");
@@ -56,9 +65,7 @@ int main(int argc, char** argv)
 
   // Start the control loop
   ros_control_boilerplate::GenericHWControlLoop control_loop(nh, moveit_sim_hw_iface);
-
-  // Wait until shutdown signal recieved
-  ros::waitForShutdown();
+  LOOP_RUN(control_loop); // blocks until shutdown is signaled
 
   return 0;
 }


### PR DESCRIPTION
I just tried this out for the first time and it didn't work.
Got it to work with these patches though.

I still can't convince myself it's a good idea to
couple the hardware simulation to the srdf, but anyway...

@davetcoleman @henningkayser @mlautman: Do you actually use this anywhere?
Do you directly use `ros_control_boilerplate sim_hw_main` or `fake_joint` instead?
We even have *partial* support for this in the setup assistant now, but it's all a bit of a mess though and no simulator actually supports velocities well...