### PR TITLE
Update .travis.yml to use moveit_ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,20 @@
+# This config file for Travis CI utilizes https://github.com/ros-planning/moveit_ci package.
 sudo: required
-dist: trusty
-language: generic # Force travis to use its minimal image with default Python settings
-compiler:
-  - gcc
+dist: xenial  # distro used by Travis, moveit_ci uses the docker image's distro
+services:
+  - docker
+language: cpp
+compiler: gcc
+cache: ccache
+
 env:
-  global:
-    - CATKIN_WS=~/catkin_ws
-    - CATKIN_WS_SRC=${CATKIN_WS}/src
-    - CI_ROS_DISTRO="indigo"
-install:
-  - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
-  - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq -y python-rosdep python-catkin-tools
-  - sudo rosdep init
-  - rosdep update
-  # Use rosdep to install all dependencies (including ROS itself)
-  - rosdep install --from-paths ./ -i -y --rosdistro $CI_ROS_DISTRO
+  matrix:
+    # - TEST="clang-format catkin_lint"
+    - ROS_DISTRO=melodic
+    - ROS_DISTRO=kinetic
+    
+before_script:
+    - git clone -q --depth=1 https://github.com/ros-planning/moveit_ci.git .moveit_ci
+
 script:
-  - source /opt/ros/$CI_ROS_DISTRO/setup.bash
-  - mkdir -p $CATKIN_WS_SRC
-  - ln -s $TRAVIS_BUILD_DIR $CATKIN_WS_SRC
-  - cd $CATKIN_WS
-  - catkin init
-  # Enable install space
-  #- catkin config --install
-  # Build [and Install] packages
-  - catkin build --limit-status-rate 0.1 --no-notify -DCMAKE_BUILD_TYPE=Release
-  # Build tests
-  - catkin build --limit-status-rate 0.1 --no-notify --make-args tests
-  # Run tests
-  - catkin run_tests
+  - .moveit_ci/travis.sh


### PR DESCRIPTION
As pointed out in https://github.com/PickNikRobotics/moveit_sim_controller/pull/4 Travis configurations is broken, this PR uses moveit_ci minimally for melodic and kinetic build 

Right now there's no clang-tidy, clang-format, warnings, or catkin_lint checks