### PR TITLE
Fix shared pointer conversion bug

### DIFF
--- a/src/moveit_sim_hw_main.cpp
+++ b/src/moveit_sim_hw_main.cpp
@@ -56,7 +56,7 @@ int main(int argc, char** argv)
   spinner.start();
 
   // Create the hardware interface specific to your robot
-  boost::shared_ptr<moveit_sim_controller::MoveItSimHWInterface> moveit_sim_hw_iface(
+  std::shared_ptr<moveit_sim_controller::MoveItSimHWInterface> moveit_sim_hw_iface(
       new moveit_sim_controller::MoveItSimHWInterface(nh));
   moveit_sim_hw_iface->init();
 


### PR DESCRIPTION
This commit pull request fixes a small bug that was introduced because [https://github.com/PickNikRobotics/ros_control_boilerplate](https://github.com/PickNikRobotics/ros_control_boilerplate)
switched to `std::shared pointers` (see https://github.com/PickNikRobotics/ros_control_boilerplate/commit/9b46eaf115c16de9e453d59085b75aa9eebc3818). 